### PR TITLE
Go1 p 22161

### DIFF
--- a/portal/PartnerType.php
+++ b/portal/PartnerType.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace go1\util\portal;
+
+use ReflectionClass;
+
+class PartnerType
+{
+    public const COMPLISPACE = 'complispace';
+    public const GO1 = 'go1';
+    public const JOBREADY = 'jobready';
+    public const JSE = 'jse';
+    public const PARTNER_HUB = 'partnerhub';
+    public const TOTARA = 'totara';
+    public const XERO = 'xero';
+
+    public static function all(): array
+    {
+        return array_values(
+            (new ReflectionClass(__CLASS__))->getConstants()
+        );
+    }
+}

--- a/portal/PartnerType.php
+++ b/portal/PartnerType.php
@@ -20,4 +20,33 @@ class PartnerType
             (new ReflectionClass(__CLASS__))->getConstants()
         );
     }
+
+    public static function toString(string $type): string
+    {
+        switch ($type) {
+            case self::COMPLISPACE:
+                return 'Complispace';
+
+            case self::GO1:
+                return 'GO1';
+
+            case self::JOBREADY:
+                return 'JobReady';
+
+            case self::JSE:
+                return 'JSE';
+
+            case self::PARTNER_HUB:
+                return 'Partner Hub';
+
+            case self::TOTARA:
+                return 'Totara';
+
+            case self::XERO:
+                return 'Xero';
+
+            default:
+                throw new InvalidArgumentException('Unknown partner type: ' . $type);
+        }
+    }
 }

--- a/tests/portal/PartnerTypeTest.php
+++ b/tests/portal/PartnerTypeTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace go1\util\tests;
+
+
+use go1\util\portal\PartnerType;
+
+class PartnerTypeTest extends UtilCoreTestCase
+{
+    public function testPartnerTypeList()
+    {
+        $partnerTypes = PartnerType::all();
+        $this->assertEquals(7, count($partnerTypes));
+    }
+}


### PR DESCRIPTION
This moves the partner types enum outside of #onboarding so that it can be used in other services