### PR TITLE
GO1P-21848 adding queue type for content import emails

### DIFF
--- a/queue/Queue.php
+++ b/queue/Queue.php
@@ -203,6 +203,7 @@ class Queue
     const LI_VIDEO_PROCESS_S3          = 'li_video.process.s3';
     const LO_UPDATE_ATTRIBUTES         = 'lo.update.attributes';
     const CONTENT_IMPORT_PROCESS_IMPORT     = 'content_import.process.import';
+    const CONTENT_IMPORT_COMPLETE      = 'notify_content_import.process.complete';
 
     # routingKey that tell some service to do something.
     #


### PR DESCRIPTION
This is needed to allow content-imports to be completed and send notifications regarding the content-import completion