### PR TITLE
Add update.lo.region event

### DIFF
--- a/queue/Queue.php
+++ b/queue/Queue.php
@@ -277,6 +277,19 @@ class Queue
     const DO_PAGEUP_UPLOAD_COURSE              = 'do.pageup.upload-couse'; # { $portal_id, $course_id }
     const REINDEX_PREFIX                       = 'go1-reindex.';
 
+    /**
+     * TEMPORARY EVENT (will be removed when premium/region restriction propagation is removed
+     *
+     * This event is to enable the marketplace consumer to break up the updating of the learning objects
+     * into manageable groups (of 5000 LOs)
+     *
+     * body = {
+     *      group: OBJECT, // the group object in which the Learning objects are.
+     *      offset: the starting offset in the list of learning objects
+     * }
+     */
+    const MARKETPLACE_UPDATE_LO_REGIONS        = 'update.lo.regions';
+
     public static function postEvent(string $event): string
     {
         return "post_{$event}";

--- a/queue/Queue.php
+++ b/queue/Queue.php
@@ -286,6 +286,7 @@ class Queue
      * body = {
      *      group: OBJECT, // the group object in which the Learning objects are.
      *      offset: the starting offset in the list of learning objects
+     *      limit: the number of learning objects to process
      * }
      */
     const MARKETPLACE_UPDATE_LO_REGIONS        = 'update.lo.regions';


### PR DESCRIPTION
The purpose of this event is to allow the premium flag / region propagation code to split up the updating of the learning objects within a group into manageable amounts.

As there are several groups with over 26000 learning objects within a group, it is not practical to update all the learning objects within a single event consumer. Initial testing showed that the processing fails (likely due to memory constraints) when attempting to update all the learning objects in a group when numbers are > that 20000.

This new even will be used by the marketplace consumer. Instead of updating all the learning objects in a single pass (when a group changes premium state or region restrictions) it will create multiple update.lo.region events, passing appropriate offset and limit values.

The marketplace consumer will also consume this event and process the learning objects as it does now. It will load each lo, compare the premium state and region restrictions against the group and update and save only if required,