### PR TITLE
Support LO.allow_enrolment enroll legacy type

### DIFF
--- a/enrolment/EnrolmentAllowTypes.php
+++ b/enrolment/EnrolmentAllowTypes.php
@@ -7,6 +7,7 @@ use InvalidArgumentException;
 class EnrolmentAllowTypes
 {
     const DEFAULT      = 'allow';
+    const ENROLL       = 'enroll'; // legacy data
     const ENQUIRY      = 'enquiry';
     const DISABLE      = 'disable';
     const SUBSCRIPTION = 'subscription';
@@ -22,6 +23,7 @@ class EnrolmentAllowTypes
     {
         switch ($type) {
             case self::DEFAULT:
+            case self::ENROLL:
                 return self::I_DEFAULT;
 
             case self::ENQUIRY:


### PR DESCRIPTION
Fix consumer error `2019/10/03 07:25:17 [error] 153#153: *1953861 FastCGI sent in stderr: "PHP message: [2019-10-03 07:25:17] payment-index.ERROR: failed to consume [lo.update] [["Unknown enrolment allow type: enroll"]] {"id":"2403292","type":"course","instance_id":"1619040","remote_id":"-2403292","origin_id":"0","language":"en","title":"CompTIA LX0-101 & LX0-102: CompTIA Linux+","description":"LPIC-1 is a junior level certification for Linux administrators. Students should\u00a0be able to perform maintenance tasks with the command line, install and\u00a0configure a workstation, and be able to configure a basic network.","private":"0","published":"1","marketplace":"1","event":null,"tags":[],"image":"https:\/\/res.cloudinary.com\/go1\/image\/upload\/v1505400222\/ahun1b98wzaxpwu2xxcb.jpg","data":{"source_id":"ITU10018","source_url":"http:\/\/dev.technologyinstitute.com\/a\/relay\/572a5f9ef40c6\/linux\/a040index.html","image":"https:\/\/res.cloudinary.com\/go1\/image\/upload\/v1505400222\/ahun1b98wzaxpwu2xxcb.jpg","imageCover":"https:\/\/res.cloudinary.com\/go1\/image\/upload\/v1505400222\/ahun1b9" while reading response header from upstream, client: 172.31.2.117, server: _, request: "POST /consume HTTP/1.0", upstream: "fastcgi://127.0.0.1:9000", host: "payment-index.production.go1.service"`