### PR TITLE
Go1P-33066_b Update the names of the constants to better reflect what they are for

### DIFF
--- a/lo/PackageLicenseTypes.php
+++ b/lo/PackageLicenseTypes.php
@@ -4,11 +4,11 @@ namespace go1\util\lo;
 
 class PackageLicenseTypes
 {
-    const SEAT   = 1;
-    const PORTAL = 2;
+    const PER_SEAT   = 1;
+    const PER_PORTAL = 2;
 
     public static function all()
     {
-        return [self::SEAT, self::PORTAL];
+        return [self::PER_SEAT, self::PER_PORTAL];
     }
 }


### PR DESCRIPTION
The constants are for the licensing model to be used by the package, that is a "per seat" license or a "per portal" license. This change improves the names of the constants to reflect this.