### PR TITLE
add a new constant for when a user doesn't have a license

### DIFF
--- a/lo/SubscriptionAccessTypes.php
+++ b/lo/SubscriptionAccessTypes.php
@@ -8,6 +8,7 @@ class SubscriptionAccessTypes
     const SUBSCRIPTION_NEEDED = 1;
     const LICENSE_NEEDED = 2;
     const LICENSED = 3;
+    const LICENSE_AVAILABLE = 4;
 
     public static function all()
     {
@@ -15,7 +16,8 @@ class SubscriptionAccessTypes
             self::NO_SUBSCRIPTION_NEEDED,
             self::SUBSCRIPTION_NEEDED,
             self::LICENSE_NEEDED,
-            self::LICENSED
+            self::LICENSED,
+            self::LICENSE_AVAILABLE
         ];
     }
 }


### PR DESCRIPTION
This new constant will signify that the user doesn't yet have a license allocated to them, but the portal has licenses available. This status will be used by the policy service to state that the user can enrol in a lesson, as the license will be claimed by the enrol service when the commence the enrolment.