### PR TITLE
PRO-271 create new attribute type and attribute for subscription renewal date

### DIFF
--- a/lo/LoAttributeTypes.php
+++ b/lo/LoAttributeTypes.php
@@ -11,6 +11,7 @@ class LoAttributeTypes
     const INTEGER   = "INTEGER";
     const TEXT      = "TEXT";
     const DIMENSION = "DIMENSION";
+    const DATE      = "DATE";
 
     public static function all()
     {

--- a/lo/LoAttributes.php
+++ b/lo/LoAttributes.php
@@ -37,6 +37,7 @@ class LoAttributes
     const CHECK_URL                     = 26;
     const ROLES                         = 27;
     const SKILLS                        = 28;
+    const SUBSCRIPTION_RENEWAL_DATE     = 29;
 
     public static function machineName(int $attribute): ?string
     {
@@ -69,6 +70,7 @@ class LoAttributes
             self::CHECK_URL                 => 'check_url',
             self::ROLES                     => 'roles',
             self::SKILLS                    => 'skills',
+            self::SUBSCRIPTION_RENWEAL_DATE => 'subscription_renewal_date',
         ];
 
         return $map[$attribute] ?? null;


### PR DESCRIPTION
This MR will create a new attribute type "DATE" and a new attribute "subscription_renewal_date" for the group LO (packages) such that a content provider can specify that the subscription will renew on the provided date. The format of the attribute will be DD/MM. Validation will occur in the learning object service (lo)