### PR TITLE
PRO-271 fix typo

### DIFF
--- a/lo/LoAttributes.php
+++ b/lo/LoAttributes.php
@@ -70,7 +70,7 @@ class LoAttributes
             self::CHECK_URL                 => 'check_url',
             self::ROLES                     => 'roles',
             self::SKILLS                    => 'skills',
-            self::SUBSCRIPTION_RENWEAL_DATE => 'subscription_renewal_date',
+            self::SUBSCRIPTION_RENEWAL_DATE => 'subscription_renewal_date',
         ];
 
         return $map[$attribute] ?? null;


### PR DESCRIPTION
In my previous util_core MR, there was a typo: SUBSCRIPTION_RENWEAL_DATE instead of SUBSCRIPTION_RENEWAL_DATE (E and W wrong way around)