### PR TITLE
CON-1247 use Currency::DEFAULT for the default currency

### DIFF
--- a/lo/LoHelper.php
+++ b/lo/LoHelper.php
@@ -6,6 +6,7 @@ use Doctrine\DBAL\Connection;
 use go1\core\util\client\federation_api\v1\schema\object\User;
 use go1\core\util\client\federation_api\v1\UserMapper;
 use go1\core\util\client\UserDomainHelper;
+use go1\util\Currency;
 use go1\util\DB;
 use go1\util\edge\EdgeHelper;
 use go1\util\edge\EdgeTypes;
@@ -86,7 +87,7 @@ class LoHelper
 
             $lo->pricing = (object) [
                 'price'        => $lo->price ? (float) $lo->price : 0.00,
-                'currency'     => $lo->currency ?: 'USD',
+                'currency'     => $lo->currency ?: Currency::DEFAULT,
                 'tax'          => $lo->tax ? (float) $lo->tax : 0.00,
                 'tax_included' => $lo->tax_included ? true : false,
                 'recurring'    => $lo->recurring ? json_decode($lo->recurring) : null,

--- a/schema/mock/LoMockTrait.php
+++ b/schema/mock/LoMockTrait.php
@@ -3,6 +3,7 @@
 namespace go1\util\schema\mock;
 
 use Doctrine\DBAL\Connection;
+use go1\util\Currency;
 use go1\util\DB;
 use go1\util\edge\EdgeTypes;
 use go1\util\lo\LiTypes;
@@ -102,7 +103,7 @@ trait LoMockTrait
             $db->insert('gc_lo_pricing', [
                 'id'           => $courseId,
                 'price'        => (float) $options['price']['price'],
-                'currency'     => isset($options['price']['currency']) ? $options['price']['currency'] : 'USD',
+                'currency'     => isset($options['price']['currency']) ? $options['price']['currency'] : Currency::DEFAULT,
                 'tax'          => isset($options['price']['tax']) ? $options['price']['tax'] : 0.00,
                 'tax_included' => isset($options['price']['tax_included']) ? $options['price']['tax_included'] : 0,
             ]);


### PR DESCRIPTION
Currently the frontend apps (editors) default to AUD. `go1\util\Currency` specifies AUD as the default value (in Currency::DEFAULT). This MR updates LoHelper and the LoMockTrait to use the same