### PR TITLE
[COD-973] Add new indice for explore (COD explore)

### DIFF
--- a/es/Schema.php
+++ b/es/Schema.php
@@ -28,6 +28,7 @@ class Schema
 
     # Indices for explore
     const EXPLORE_INDEX             = ES_INDEX . '_explore';
+    const COD_EXPLORE_INDEX         = ES_INDEX . '_cod_explore';
     const EXPLORE_GROUP_INDEX       = ES_INDEX . '_explore_group';
     const EXPLORE_MARKETPLACE_INDEX = ES_INDEX . '_explore_marketplace';
 


### PR DESCRIPTION
Content Discovery needs a new ElasticSearch index to use with the new indexer (called COD-indexer)

# What did I do in this PR?
- Add a new key to ES Schema called COD_EXPLORE_INDEX.